### PR TITLE
fix a wrong FQCN (lowercased)

### DIFF
--- a/src/services.xml
+++ b/src/services.xml
@@ -61,7 +61,7 @@
             </argument>
         </service>
 
-        <service id="rmiller.phpspec_extension.tester" class="RMiller\PhpSpecExtension\tester\PhpSpecTester">
+        <service id="rmiller.phpspec_extension.tester" class="RMiller\PhpSpecExtension\Tester\PhpSpecTester">
             <argument/>
             <argument type="service" id="rmiller.phpspec_extension.desc_runner"/>
             <argument type="service" id="cli.output"/>


### PR DESCRIPTION
resolves this exception:

```
[ReflectionException]
Class RMiller\PhpSpecExtension\tester\PhpSpecTester does not exist
```
