### PR TITLE
Allow rmiller/phpspec-extension to work with Symfony3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php":             ">=5.4",
         "behat/behat":     "~3.0,>=3.0.4",
         "phpspec/phpspec": "~2.0",
-        "symfony/process": "~2.1"
+        "symfony/process": "~2.1|~3.0"
     },
     "require-dev": {
         "rmiller/error-extension": "~0.1",


### PR DESCRIPTION
Just add Symfony3 compatibility in composer.json (because symfony/symfony use self.version compatibility).

__Need tests!__